### PR TITLE
允许配置缓存Key前缀

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -75,7 +75,7 @@ func (c *Gorm2Cache) Init() error {
 		c.Config.KeyPrefix = "gormcache"
 	}
 
-	prefix := c.Config.KeyPrefix + ":" + c.InstanceId
+	prefix := c.Config.KeyPrefix + c.InstanceId
 
 	if c.Config.CacheStorage == config.CacheStorageRedis {
 		c.cache = &data_layer.RedisLayer{}

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -25,7 +25,7 @@ type Gorm2Cache struct {
 }
 
 func (c *Gorm2Cache) Name() string {
-	return util.GormCachePrefix
+	return c.Config.KeyPrefix
 }
 
 func (c *Gorm2Cache) Initialize(db *gorm.DB) (err error) {
@@ -70,7 +70,12 @@ func (c *Gorm2Cache) Init() error {
 	}
 	c.InstanceId = util.GenInstanceId()
 
-	prefix := util.GormCachePrefix + ":" + c.InstanceId
+	// if key prefix is empty, set default value
+	if c.Config.KeyPrefix == "" {
+		c.Config.KeyPrefix = "gormcache"
+	}
+
+	prefix := c.Config.KeyPrefix + ":" + c.InstanceId
 
 	if c.Config.CacheStorage == config.CacheStorageRedis {
 		c.cache = &data_layer.RedisLayer{}
@@ -116,48 +121,48 @@ func (c *Gorm2Cache) ResetCache() error {
 }
 
 func (c *Gorm2Cache) InvalidateSearchCache(ctx context.Context, tableName string) error {
-	return c.cache.DeleteKeysWithPrefix(ctx, util.GenSearchCachePrefix(c.InstanceId, tableName))
+	return c.cache.DeleteKeysWithPrefix(ctx, util.GenSearchCachePrefix(c.Config.KeyPrefix, c.InstanceId, tableName))
 }
 
 func (c *Gorm2Cache) InvalidatePrimaryCache(ctx context.Context, tableName string, primaryKey string) error {
-	return c.cache.DeleteKey(ctx, util.GenPrimaryCacheKey(c.InstanceId, tableName, primaryKey))
+	return c.cache.DeleteKey(ctx, util.GenPrimaryCacheKey(c.Config.KeyPrefix, c.InstanceId, tableName, primaryKey))
 }
 
 func (c *Gorm2Cache) BatchInvalidatePrimaryCache(ctx context.Context, tableName string, primaryKeys []string) error {
 	cacheKeys := make([]string, 0, len(primaryKeys))
 	for _, primaryKey := range primaryKeys {
-		cacheKeys = append(cacheKeys, util.GenPrimaryCacheKey(c.InstanceId, tableName, primaryKey))
+		cacheKeys = append(cacheKeys, util.GenPrimaryCacheKey(c.Config.KeyPrefix, c.InstanceId, tableName, primaryKey))
 	}
 	return c.cache.BatchDeleteKeys(ctx, cacheKeys)
 }
 
 func (c *Gorm2Cache) InvalidateAllPrimaryCache(ctx context.Context, tableName string) error {
-	return c.cache.DeleteKeysWithPrefix(ctx, util.GenPrimaryCachePrefix(c.InstanceId, tableName))
+	return c.cache.DeleteKeysWithPrefix(ctx, util.GenPrimaryCachePrefix(c.Config.KeyPrefix, c.InstanceId, tableName))
 }
 
 func (c *Gorm2Cache) BatchPrimaryKeyExists(ctx context.Context, tableName string, primaryKeys []string) (bool, error) {
 	cacheKeys := make([]string, 0, len(primaryKeys))
 	for _, primaryKey := range primaryKeys {
-		cacheKeys = append(cacheKeys, util.GenPrimaryCacheKey(c.InstanceId, tableName, primaryKey))
+		cacheKeys = append(cacheKeys, util.GenPrimaryCacheKey(c.Config.KeyPrefix, c.InstanceId, tableName, primaryKey))
 	}
 	return c.cache.BatchKeyExist(ctx, cacheKeys)
 }
 
 func (c *Gorm2Cache) SearchKeyExists(ctx context.Context, tableName string, SQL string, vars ...interface{}) (bool, error) {
-	cacheKey := util.GenSearchCacheKey(c.InstanceId, tableName, SQL, vars...)
+	cacheKey := util.GenSearchCacheKey(c.Config.KeyPrefix, c.InstanceId, tableName, SQL, vars...)
 	return c.cache.KeyExists(ctx, cacheKey)
 }
 
 func (c *Gorm2Cache) BatchSetPrimaryKeyCache(ctx context.Context, tableName string, kvs []util.Kv) error {
 	for idx, kv := range kvs {
-		kvs[idx].Key = util.GenPrimaryCacheKey(c.InstanceId, tableName, kv.Key)
+		kvs[idx].Key = util.GenPrimaryCacheKey(c.Config.KeyPrefix, c.InstanceId, tableName, kv.Key)
 	}
 	return c.cache.BatchSetKeys(ctx, kvs)
 }
 
 func (c *Gorm2Cache) SetSearchCache(ctx context.Context, cacheValue string, tableName string,
 	sql string, vars ...interface{}) error {
-	key := util.GenSearchCacheKey(c.InstanceId, tableName, sql, vars...)
+	key := util.GenSearchCacheKey(c.Config.KeyPrefix, c.InstanceId, tableName, sql, vars...)
 	return c.cache.SetKey(ctx, util.Kv{
 		Key:   key,
 		Value: cacheValue,
@@ -165,14 +170,14 @@ func (c *Gorm2Cache) SetSearchCache(ctx context.Context, cacheValue string, tabl
 }
 
 func (c *Gorm2Cache) GetSearchCache(ctx context.Context, tableName string, sql string, vars ...interface{}) (string, error) {
-	key := util.GenSearchCacheKey(c.InstanceId, tableName, sql, vars...)
+	key := util.GenSearchCacheKey(c.Config.KeyPrefix, c.InstanceId, tableName, sql, vars...)
 	return c.cache.GetValue(ctx, key)
 }
 
 func (c *Gorm2Cache) BatchGetPrimaryCache(ctx context.Context, tableName string, primaryKeys []string) ([]string, error) {
 	cacheKeys := make([]string, 0, len(primaryKeys))
 	for _, primaryKey := range primaryKeys {
-		cacheKeys = append(cacheKeys, util.GenPrimaryCacheKey(c.InstanceId, tableName, primaryKey))
+		cacheKeys = append(cacheKeys, util.GenPrimaryCacheKey(c.Config.KeyPrefix, c.InstanceId, tableName, primaryKey))
 	}
 	return c.cache.BatchGetValues(ctx, cacheKeys)
 }

--- a/config/config.go
+++ b/config/config.go
@@ -10,6 +10,9 @@ type CacheConfig struct {
 	// RedisConfig if storage is redis, then this config needs to be setup
 	RedisConfig *RedisConfig
 
+	// cache key prefix
+	KeyPrefix string
+
 	// Tables only cache data within given data tables (cache all if empty)
 	Tables []string
 

--- a/data_layer/redis.go
+++ b/data_layer/redis.go
@@ -69,7 +69,7 @@ func (r *RedisLayer) initScripts() error {
 }
 
 func (r *RedisLayer) CleanCache(ctx context.Context) error {
-	result := r.client.EvalSha(ctx, r.cleanCacheSha, []string{"0"}, r.keyPrefix+":*")
+	result := r.client.EvalSha(ctx, r.cleanCacheSha, []string{"0"}, r.keyPrefix+"*")
 	if result.Err() != nil {
 		r.logger.CtxError(ctx, "[CleanCache] clean cache error: %v", result.Err())
 		return result.Err()
@@ -119,7 +119,7 @@ func (r *RedisLayer) BatchGetValues(ctx context.Context, keys []string) ([]strin
 }
 
 func (r *RedisLayer) DeleteKeysWithPrefix(ctx context.Context, keyPrefix string) error {
-	result := r.client.EvalSha(ctx, r.cleanCacheSha, []string{"0"}, keyPrefix+":*")
+	result := r.client.EvalSha(ctx, r.cleanCacheSha, []string{"0"}, keyPrefix+"*")
 	return result.Err()
 }
 

--- a/util/definition.go
+++ b/util/definition.go
@@ -13,6 +13,3 @@ type Kv struct {
 	Value string
 }
 
-const (
-	GormCachePrefix = "gormcache"
-)

--- a/util/key.go
+++ b/util/key.go
@@ -1,3 +1,11 @@
+/*
+ * @Author: nijineko
+ * @Date: 2024-04-22 10:46:20
+ * @LastEditTime: 2024-04-22 10:54:58
+ * @LastEditors: nijineko
+ * @Description:
+ * @FilePath: \gorm-cache\util\key.go
+ */
 package util
 
 import (
@@ -19,15 +27,15 @@ func GenInstanceId() string {
 	return string(str)
 }
 
-func GenPrimaryCacheKey(instanceId string, tableName string, primaryKey string) string {
-	return fmt.Sprintf("%s:%s:p:%s:%s", GormCachePrefix, instanceId, tableName, primaryKey)
+func GenPrimaryCacheKey(KeyPrefix string, instanceId string, tableName string, primaryKey string) string {
+	return fmt.Sprintf("%s:%s:p:%s:%s", KeyPrefix, instanceId, tableName, primaryKey)
 }
 
-func GenPrimaryCachePrefix(instanceId string, tableName string) string {
-	return GormCachePrefix + ":" + instanceId + ":p:" + tableName
+func GenPrimaryCachePrefix(KeyPrefix string, instanceId string, tableName string) string {
+	return KeyPrefix + ":" + instanceId + ":p:" + tableName
 }
 
-func GenSearchCacheKey(instanceId string, tableName string, sql string, vars ...interface{}) string {
+func GenSearchCacheKey(KeyPrefix string, instanceId string, tableName string, sql string, vars ...interface{}) string {
 	buf := strings.Builder{}
 	buf.WriteString(sql)
 	for _, v := range vars {
@@ -38,9 +46,9 @@ func GenSearchCacheKey(instanceId string, tableName string, sql string, vars ...
 			buf.WriteString(fmt.Sprintf(":%v", v))
 		}
 	}
-	return fmt.Sprintf("%s:%s:s:%s:%s", GormCachePrefix, instanceId, tableName, buf.String())
+	return fmt.Sprintf("%s:%s:s:%s:%s", KeyPrefix, instanceId, tableName, buf.String())
 }
 
-func GenSearchCachePrefix(instanceId string, tableName string) string {
-	return GormCachePrefix + ":" + instanceId + ":s:" + tableName
+func GenSearchCachePrefix(KeyPrefix string, instanceId string, tableName string) string {
+	return KeyPrefix + ":" + instanceId + ":s:" + tableName
 }

--- a/util/key.go
+++ b/util/key.go
@@ -28,11 +28,11 @@ func GenInstanceId() string {
 }
 
 func GenPrimaryCacheKey(KeyPrefix string, instanceId string, tableName string, primaryKey string) string {
-	return fmt.Sprintf("%s:%s:p:%s:%s", KeyPrefix, instanceId, tableName, primaryKey)
+	return fmt.Sprintf("%s%s:p:%s:%s", KeyPrefix, instanceId, tableName, primaryKey)
 }
 
 func GenPrimaryCachePrefix(KeyPrefix string, instanceId string, tableName string) string {
-	return KeyPrefix + ":" + instanceId + ":p:" + tableName
+	return KeyPrefix + instanceId + ":p:" + tableName
 }
 
 func GenSearchCacheKey(KeyPrefix string, instanceId string, tableName string, sql string, vars ...interface{}) string {
@@ -46,9 +46,9 @@ func GenSearchCacheKey(KeyPrefix string, instanceId string, tableName string, sq
 			buf.WriteString(fmt.Sprintf(":%v", v))
 		}
 	}
-	return fmt.Sprintf("%s:%s:s:%s:%s", KeyPrefix, instanceId, tableName, buf.String())
+	return fmt.Sprintf("%s%s:s:%s:%s", KeyPrefix, instanceId, tableName, buf.String())
 }
 
 func GenSearchCachePrefix(KeyPrefix string, instanceId string, tableName string) string {
-	return KeyPrefix + ":" + instanceId + ":s:" + tableName
+	return KeyPrefix + instanceId + ":s:" + tableName
 }


### PR DESCRIPTION
1. 全局配置添加`KeyPrefix`用于配置缓存Key前缀
2. 适配Key前缀配置更改
3. 删除`util/definition.go`内的`GormCachePrefix`全局变量
4. 如果没有填写Key前缀配置，则使用默认的`gormcache`前缀，兼容旧版本