### PR TITLE
Add Multi-instance support for redis storage

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -70,7 +70,7 @@ func (c *Gorm2Cache) Init() error {
 		c.InstanceId = c.Config.MultiInstanceKey
 	}
 
-	if c.Config.CacheStorage == config.CacheStorageMemory {
+	if c.InstanceId == "" {
 		c.InstanceId = util.GenInstanceId()
 	}
 

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -67,8 +67,12 @@ func (c *Gorm2Cache) Init() error {
 			panic("please init redis config!")
 		}
 		c.Config.RedisConfig.InitClient()
+		c.InstanceId = c.Config.MultiInstanceKey
 	}
-	c.InstanceId = util.GenInstanceId()
+
+	if c.Config.CacheStorage == config.CacheStorageMemory {
+		c.InstanceId = util.GenInstanceId()
+	}
 
 	prefix := util.GormCachePrefix + ":" + c.InstanceId
 

--- a/config/config.go
+++ b/config/config.go
@@ -33,6 +33,9 @@ type CacheConfig struct {
 
 	// DebugLogger
 	DebugLogger LoggerInterface
+
+	// MultiInstanceKey Use same cache instance for different instances if using redis
+	MultiInstanceKey string
 }
 
 type CacheLevel int


### PR DESCRIPTION
Support for using same redis space when running multiple servers.

When running multiple  app servers for the same app, all the servers are connected same DB. So it make sense to add use common cache.

Example:
If there are 2 items in the list for instance A and 2 items in list for instance B. If one item gets deleted. Cache should be invalidated for both instances. 